### PR TITLE
Add Vault Deployment

### DIFF
--- a/modules/deployment-vault/files/cloud-config.yaml
+++ b/modules/deployment-vault/files/cloud-config.yaml
@@ -1,6 +1,10 @@
 #cloud-config
 write_files:
 
+  - path: /tmp/ca/ca.crt
+    encoding: base64
+    content: ${ca_cert_b64}
+
   - path: /tmp/vault/tls.key
     encoding: base64
     content: ${tls_key_b64}
@@ -27,11 +31,6 @@ write_files:
       api_addr     = "http://${api_addr}:${https_port}"
       ui           = true
 
-ca_certs:
-  trusted:
-    - |-
-      ${ca_cert_oneline}
-
 ntp:
   enabled: true
   ntp_client: chrony
@@ -45,6 +44,8 @@ packages:
   - curl
 
 runcmd:
+  - "mv /tmp/ca/ca.crt /usr/local/share/ca-certificates/"
+  - "update-ca-certificates"
   - "curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -"
   - 'apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"'
   - "apt-get -y update"

--- a/modules/deployment-vault/files/cloud-config.yaml
+++ b/modules/deployment-vault/files/cloud-config.yaml
@@ -1,0 +1,60 @@
+#cloud-config
+write_files:
+
+  - path: /tmp/vault/tls.key
+    encoding: base64
+    content: ${tls_key_b64}
+
+  - path: /tmp/vault/tls.crt
+    encoding: base64
+    content: ${tls_cert_b64}
+
+  - path: /tmp/vault/vault.hcl
+    content: |
+      storage "file" {
+        path = "${persistent_mount}"
+      }
+      listener "tcp" {
+        address       = "${https_addr}:${https_port}"
+        tls_cert_file = "/opt/vault/tls/tls.crt"
+        tls_key_file  = "/opt/vault/tls/tls.key"
+      }
+      telemetry "prometheus" {
+        prometheus_retention_time = "12h"
+        disable_hostname          = true
+      }
+      mlock        = true
+      api_addr     = "http://${api_addr}:${https_port}"
+      ui           = true
+
+ca_certs:
+  trusted:
+    - |-
+      ${ca_cert_oneline}
+
+ntp:
+  enabled: true
+  ntp_client: chrony
+
+# enable when clean boot up & config is sorted out
+package_update: false
+package_upgrade: false
+
+packages:
+  - software-properties-common
+  - curl
+
+runcmd:
+  - "curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -"
+  - 'apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"'
+  - "apt-get -y update"
+  - "apt-get -y install vault"
+  - "setcap cap_ipc_lock=+ep $(readlink -f $(which vault))"
+  - "mv /tmp/vault/tls.crt /opt/vault/tls/tls.crt"
+  - "mv /tmp/vault/tls.key /opt/vault/tls/tls.key"
+  - "chown vault:vault /opt/vault/tls/*"
+  - "mv /tmp/vault/vault.hcl /etc/vault.d/vault.hcl"
+  - "chown vault:vault /etc/vault.d/vault.hcl"
+  - "chown -R vault:vault ${persistent_mount}"
+  - "systemctl enable --now vault.service"
+  - "shutdown -r now"

--- a/modules/deployment-vault/locals.tf
+++ b/modules/deployment-vault/locals.tf
@@ -1,0 +1,48 @@
+locals {
+  # simple naming
+  name = coalesce(var.name, var.project_name)
+
+  # everything this module creates gets these
+  module_tags = [
+    "role:secrets",
+    "app:vault",
+  ]
+
+  tags = toset(concat(
+    local.module_tags,
+    var.tags,
+  ))
+
+  cloudinit_config_parts = merge(
+    var.cloudinit_config_parts,
+    {
+      "cloud-config" = {
+        content_type = "text/cloud-config"
+        content = templatefile(
+          "./files/cloud-config.yaml",
+          {
+            persistent_mount = var.volume_mount
+            https_port       = var.https_port
+            https_addr       = "0.0.0.0"
+            api_addr         = "127.0.0.1"
+            tls_cert_b64     = var.tls_cert_b64
+            tls_key_b64      = var.tls_key_b64
+            ca_cert_oneline  = var.ca_cert_oneline
+          },
+        )
+      }
+    }
+  )
+
+  inbound_rules = merge(
+    var.inbound_rules,
+    {
+      "https" = {
+        port_range       = var.https_port
+        protocol         = "tcp"
+        source_addresses = var.client_source_addresses
+        source_tags      = ["access:${var.name}"]
+      }
+    }
+  )
+}

--- a/modules/deployment-vault/locals.tf
+++ b/modules/deployment-vault/locals.tf
@@ -27,7 +27,7 @@ locals {
             api_addr         = "127.0.0.1"
             tls_cert_b64     = var.tls_cert_b64
             tls_key_b64      = var.tls_key_b64
-            ca_cert_oneline  = var.ca_cert_oneline
+            ca_cert_b64      = var.ca_cert_b64
           },
         )
       }

--- a/modules/deployment-vault/main.tf
+++ b/modules/deployment-vault/main.tf
@@ -1,5 +1,5 @@
 module "deployment" {
-  source                      = "git::ssh://git@github.com/haggishunk/terraform-digitalocean-modules.git//modules/deployment?ref=firewall-tags-on-droplet"
+  source                      = "git::ssh://git@github.com/haggishunk/terraform-digitalocean-modules.git//modules/deployment?ref=1.2.1"
   ca_trust_enabled            = false # handled by cloudinit
   certs_enabled               = false # handled by cloudinit
   cloudinit_config_parts      = local.cloudinit_config_parts

--- a/modules/deployment-vault/main.tf
+++ b/modules/deployment-vault/main.tf
@@ -1,5 +1,5 @@
 module "deployment" {
-  source                      = "git::ssh://git@github.com/haggishunk/terraform-digitalocean-modules.git//modules/deployment?ref=1.2.0"
+  source                      = "git::ssh://git@github.com/haggishunk/terraform-digitalocean-modules.git//modules/deployment?ref=firewall-tags-on-droplet"
   ca_trust_enabled            = false # handled by cloudinit
   certs_enabled               = false # handled by cloudinit
   cloudinit_config_parts      = local.cloudinit_config_parts

--- a/modules/deployment-vault/main.tf
+++ b/modules/deployment-vault/main.tf
@@ -1,0 +1,37 @@
+module "deployment" {
+  source                      = "git::ssh://git@github.com/haggishunk/terraform-digitalocean-modules.git//modules/deployment?ref=1.2.0"
+  ca_trust_enabled            = false # handled by cloudinit
+  certs_enabled               = false # handled by cloudinit
+  cloudinit_config_parts      = local.cloudinit_config_parts
+  cloudinit_enabled           = true
+  dns_enabled                 = var.dns_enabled
+  domain                      = var.domain
+  image_filters               = var.image_filters
+  image_id                    = var.image_id
+  image_latest                = var.image_latest
+  image_name                  = var.image_name
+  image_slug                  = var.image_slug
+  image_sort                  = var.image_sort
+  image_source                = var.image_source
+  inbound_rules               = local.inbound_rules
+  monitoring                  = var.monitoring
+  name                        = local.name
+  outbound_rules              = var.outbound_rules
+  project_name                = var.project_name
+  region                      = var.region
+  reserved_ip_enabled         = var.reserved_ip_enabled
+  size                        = var.size
+  ssh_enabled                 = var.ssh_enabled
+  ssh_keys_ids                = var.ssh_keys_ids
+  ssh_keys_names              = var.ssh_keys_names
+  tags                        = local.tags
+  volume_description          = var.volume_description
+  volume_enabled              = var.volume_enabled
+  volume_fs                   = var.volume_fs
+  volume_mount                = var.volume_mount
+  volume_name                 = var.volume_name
+  volume_size                 = var.volume_size
+  volume_snapshot_most_recent = var.volume_snapshot_most_recent
+  volume_snapshot_name        = var.volume_snapshot_name
+  vpc_uuid                    = var.vpc_uuid
+}

--- a/modules/deployment-vault/~inputs.tf
+++ b/modules/deployment-vault/~inputs.tf
@@ -188,7 +188,7 @@ variable "tls_key" {
 
 variable "ca_cert" {
   type    = string
-  default = "DEFUNCT see `ca_cert_oneline`"
+  default = "DEFUNCT see `ca_cert_b64`"
 }
 
 variable "ca_trust_enabled" {
@@ -226,7 +226,7 @@ variable "tls_key_b64" {
   type = string
 }
 
-variable "ca_cert_oneline" {
+variable "ca_cert_b64" {
   type = string
 }
 

--- a/modules/deployment-vault/~inputs.tf
+++ b/modules/deployment-vault/~inputs.tf
@@ -1,0 +1,241 @@
+# project level
+variable "project_name" {
+  type = string
+}
+
+# module level
+variable "name" {
+  type = string
+}
+
+variable "tags" {
+  type        = list(string)
+  description = "List of tag strings"
+}
+
+variable "size" {
+  type    = string
+  default = "1gb"
+}
+
+variable "image_id" {
+  type        = string
+  description = "(Optional) This id will be added as an exact match on image filters."
+  default     = null
+}
+
+variable "image_name" {
+  type        = string
+  description = "(Optional) This name will be added as a regex match on image filters."
+  default     = null
+}
+
+variable "image_slug" {
+  type        = string
+  description = "(Optional) This slug will be added as a regex match on image filters."
+  default     = null
+}
+
+variable "image_source" {
+  type        = string
+  description = "(Optional) This source (distribution) will be added as an exact match on image filters."
+  default     = null
+}
+
+variable "image_filters" {
+  type = map(object({
+    key      = string
+    values   = list(string)
+    match_by = string
+    all      = bool
+  }))
+  description = "(Optional) Map of objects representing filter `key`, `values`, `match_by` and `all` for image selection."
+  default     = {}
+}
+
+variable "image_latest" {
+  type        = bool
+  description = "(Optional) Set to `true` to pick the latest of image that matches provided filters and arranged by sort.  Defaults to `true`."
+  default     = true
+}
+
+variable "image_sort" {
+  type        = map(string)
+  description = "(Optional) Map of sort `key`, `direction` for droplet images.  Note that the default setting of `image_latest` to `true` overrides anything specified here."
+  default     = {}
+}
+
+variable "region" {
+  type        = string
+  description = "Region to deploy resources to.  Also filters droplet images."
+}
+
+variable "vpc_uuid" {
+  type        = string
+  default     = null
+  description = "The VPC uuid if private networking is desired.  Default is `null` which locates the droplet in the default vpc."
+}
+
+variable "monitoring" {
+  type    = bool
+  default = true
+}
+
+variable "ssh_enabled" {
+  type    = bool
+  default = false
+}
+
+variable "ssh_keys_ids" {
+  type    = list(string)
+  default = []
+}
+
+variable "ssh_keys_names" {
+  type    = list(string)
+  default = []
+}
+
+variable "dns_enabled" {
+  type    = bool
+  default = false
+}
+
+variable "domain" {
+  type    = string
+  default = null
+}
+
+variable "reserved_ip_enabled" {
+  type    = bool
+  default = false
+}
+
+variable "volume_enabled" {
+  type    = bool
+  default = false
+}
+
+variable "volume_snapshot_name" {
+  type    = string
+  default = null
+}
+
+variable "volume_snapshot_most_recent" {
+  type    = bool
+  default = true
+}
+
+variable "volume_name" {
+  type    = string
+  default = "data"
+}
+
+variable "volume_mount" {
+  type    = string
+  default = "/var/lib/vault"
+}
+
+variable "volume_size" {
+  type    = number
+  default = 10
+}
+
+variable "volume_fs" {
+  type    = string
+  default = "ext4"
+}
+
+variable "volume_description" {
+  type    = string
+  default = null
+}
+
+variable "inbound_rules" {
+  type = map(object({
+    port_range       = string
+    protocol         = string
+    source_addresses = list(string)
+    source_tags      = list(string)
+  }))
+  default = {}
+}
+
+variable "outbound_rules" {
+  type = map(object({
+    port_range            = string
+    protocol              = string
+    destination_addresses = list(string)
+    destination_tags      = list(string)
+  }))
+  default = {}
+}
+
+variable "certs_enabled" {
+  type    = bool
+  default = false
+}
+
+variable "tls_cert" {
+  type    = string
+  default = "DEFUNCT see `tls_cert_b64`"
+}
+
+variable "tls_key" {
+  type    = string
+  default = "DEFUNCT see `tls_key_b64`"
+}
+
+variable "ca_cert" {
+  type    = string
+  default = "DEFUNCT see `ca_cert_oneline`"
+}
+
+variable "ca_trust_enabled" {
+  type    = bool
+  default = false
+}
+
+variable "cert_path" {
+  type    = string
+  default = "/etc/certificates"
+}
+
+variable "cloudinit_enabled" {
+  type        = bool
+  description = "(Optional) Enable cloudinit scripts supplied via `cloudinit_config_parts`.  Note that setting `volume_enabled` will execute a cloudinit script not enabled/disabled by this setting."
+  default     = true
+}
+
+variable "cloudinit_config_parts" {
+  type = map(object({
+    content      = string
+    content_type = string
+  }))
+  description = "(Optional) Map of content and content type to construct into cloudinit script."
+  default     = {}
+}
+
+# vault variables
+
+variable "tls_cert_b64" {
+  type = string
+}
+
+variable "tls_key_b64" {
+  type = string
+}
+
+variable "ca_cert_oneline" {
+  type = string
+}
+
+variable "client_source_addresses" {
+  type    = list(string)
+  default = []
+}
+
+variable "https_port" {
+  type    = string
+  default = "8200"
+}

--- a/modules/deployment-vault/~outputs.tf
+++ b/modules/deployment-vault/~outputs.tf
@@ -1,0 +1,57 @@
+output "droplet_dnsname" {
+  value = var.dns_enabled ? module.deployment.droplet_dnsname : null
+}
+
+output "reserved_ip" {
+  value = var.reserved_ip_enabled ? module.deployment.reserved_ip : null
+}
+
+output "droplet_ip" {
+  value = module.deployment.droplet_ip
+}
+
+output "cloudinit_configs" {
+  value       = var.cloudinit_enabled ? keys(local.cloudinit_config_parts) : null
+  description = "A list of enabled cloudinit configurations"
+}
+
+output "deployment_tags" {
+  value = module.deployment.deployment_tags
+}
+
+output "tags" {
+  value = module.deployment.tags
+}
+
+output "firewall_tags" {
+  value = module.deployment.firewall_tags
+}
+
+output "cloudinit_rendered" {
+  value     = var.cloudinit_enabled ? module.deployment.cloudinit_rendered : null
+  sensitive = true # inspect state to debug rendered cloudinit parts
+}
+
+output "droplet_image" {
+  value = module.deployment.droplet_image
+}
+
+output "volume_id" {
+  value = var.volume_enabled ? module.deployment.volume_id : null
+}
+
+output "volume_name" {
+  value = var.volume_enabled ? module.deployment.volume_name : null
+}
+
+output "volume_region" {
+  value = var.volume_enabled ? module.deployment.volume_region : null
+}
+
+output "volume_snapshot_id" {
+  value = var.volume_enabled ? module.deployment.volume_snapshot_id : null
+}
+
+output "volume_snapshot_filesystem_type" {
+  value = var.volume_enabled ? module.deployment.volume_snapshot_filesystem_type : null
+}


### PR DESCRIPTION
- Manually using update-ca-certificates since ca_cert cloud init does not support base64 encoded strings.  Templating a supplied ca cert into a yaml multiline field is troublesome.
