### PR TITLE
Prevent Empty Certbot Secret

### DIFF
--- a/modules/deployment-vault/main.tf
+++ b/modules/deployment-vault/main.tf
@@ -34,4 +34,15 @@ module "deployment" {
   volume_snapshot_most_recent = var.volume_snapshot_most_recent
   volume_snapshot_name        = var.volume_snapshot_name
   vpc_uuid                    = var.vpc_uuid
+
+  depends_on = [resource.null_resource.certbot_check]
+}
+
+resource "null_resource" "certbot_check" {
+  lifecycle {
+    precondition {
+      condition     = var.certbot_enabled && length(var.digitalocean_token) > 0
+      error_message = "If certbot is enabled, digital ocean token must be supplied"
+    }
+  }
 }

--- a/modules/deployment-vault/~inputs.tf
+++ b/modules/deployment-vault/~inputs.tf
@@ -254,5 +254,5 @@ variable "certbot_email" {
 
 variable "digitalocean_token" {
   type    = string
-  default = "no-token"
+  default = ""
 }


### PR DESCRIPTION
- Added a null resource to check that the certbot secret is not empty if certbot is enabled.
- Set primary resource module to depend on null resource.
